### PR TITLE
add moment timezone to convert event time to users local time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fullcalendar/daygrid": "^6.1.8",
         "@fullcalendar/icalendar": "^6.1.8",
         "@fullcalendar/interaction": "^6.1.8",
+        "@fullcalendar/moment-timezone": "^6.1.9",
         "@fullcalendar/react": "^6.1.8",
         "@fullcalendar/timegrid": "^6.1.8",
         "html-react-parser": "^4.2.2",
@@ -885,6 +886,15 @@
       "integrity": "sha512-I3FGnv0kKZpIwujg3HllbKrciNjTqeTYy3oJG226oAn7lV6wnrrDYMmuGmA0jPJAGN46HKrQqKN7ItxQRDec4Q==",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.9"
+      }
+    },
+    "node_modules/@fullcalendar/moment-timezone": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/moment-timezone/-/moment-timezone-6.1.9.tgz",
+      "integrity": "sha512-TpUpicnvNZU9+d6wvRJG62Eu+v/x9SwZelN7JH46hUgfnbV2ErWsbKcj0AeBcyqaZYLJI2cdWN4NhHmHThqRVQ==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.9",
+        "moment-timezone": "^0.5.40"
       }
     },
     "node_modules/@fullcalendar/react": {
@@ -3023,6 +3033,27 @@
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "peer": true,
+      "dependencies": {
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fullcalendar/daygrid": "^6.1.8",
     "@fullcalendar/icalendar": "^6.1.8",
     "@fullcalendar/interaction": "^6.1.8",
+    "@fullcalendar/moment-timezone": "^6.1.9",
     "@fullcalendar/react": "^6.1.8",
     "@fullcalendar/timegrid": "^6.1.8",
     "html-react-parser": "^4.2.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import iCalendarPlugin from '@fullcalendar/icalendar';
 import interactionPlugin from '@fullcalendar/interaction';
 import parse from 'html-react-parser';
 import timeGridPlugin from '@fullcalendar/timegrid';
-import momentTimezonePlugin from '@fullcalendar/moment-timezone'
+import momentTimezonePlugin from '@fullcalendar/moment-timezone';
 
 import useEscKey from './hooks/useEscKey';
 
@@ -14,87 +14,84 @@ import './App.css';
 const htmlRegex = /<\/*html-blob>/;
 
 function App() {
-  const calendarRef = createRef();
+	const calendarRef = createRef();
 
-  const [loading, setLoading] = useState(true);
-  const [showEventDetails, setShowEventDetails] = useState(false);
-  const [eventDetails, setEventDetails] = useState(false);
+	const [ loading, setLoading ] = useState(true);
+	const [ showEventDetails, setShowEventDetails ] = useState(false);
+	const [ eventDetails, setEventDetails ] = useState(false);
 
-  useEscKey(() => setShowEventDetails(false));
+	useEscKey(() => setShowEventDetails(false));
 
-  const handleEventClick = useCallback((clickInfo) => {
-    setEventDetails(clickInfo.event);
-    setShowEventDetails(true);
-  });
+	const handleEventClick = useCallback((clickInfo) => {
+		setEventDetails(clickInfo.event);
+		setShowEventDetails(true);
+	});
 
-  const renderEventDetails = () => {
-    const description = eventDetails.extendedProps.description.replace(
-      htmlRegex,
-      ''
-    );
+	const renderEventDetails = () => {
+		const description = eventDetails.extendedProps.description.replace(htmlRegex, '');
 
-    return (
-      <div className="finos-calendar-event-details">
-        <button
-          onClick={() => setShowEventDetails(false)}
-          className="fc-button finos-calendar-event-details-close"
-        >
-          X
-        </button>
-        <h2>{eventDetails.title}</h2>
-        <div>
-          <strong>Start:</strong> {eventDetails.start.toString()}
-        </div>
-        <div>
-          <strong>End:</strong> {eventDetails.end.toString()}
-        </div>
-        {parse(description)}
-      </div>
-    );
-  };
+		return (
+			<div className="finos-calendar-event-details">
+				<button
+					onClick={() => setShowEventDetails(false)}
+					className="fc-button finos-calendar-event-details-close"
+				>
+					X
+				</button>
+				<h2>{eventDetails.title}</h2>
+				<div>
+					<strong>Start:</strong> {eventDetails.start.toString().replace(/ GMT\+\d{4}\s/g, ' ')}
+				</div>
+				<div>
+					<strong>End:</strong> {eventDetails.end.toString().replace(/ GMT\+\d{4}\s/g, ' ')}
+				</div>
+				{parse(description)}
+			</div>
+		);
+	};
 
-  const renderFullCalendar = useMemo(
-    () => (
-      <FullCalendar
-        ref={calendarRef}
-        plugins={[
-          dayGridPlugin,
-          iCalendarPlugin,
-          interactionPlugin,
-          timeGridPlugin,
-          momentTimezonePlugin,
-        ]}
-        initialView="dayGridMonth"
-        events={{
-          url: 'basic.ics',
-          format: 'ics',
-        }}
-        headerToolbar={{
-          left: 'prev,next today',
-          center: 'title',
-          right: 'dayGridMonth,timeGridWeek,timeGridDay',
-        }}
-        dayMaxEventRows={999}
-        initialDate={new Date().toISOString().slice(0, 10)}
-        navLinks
-        editable
-        dayMaxEvents
-        timeZone='America/New_York'
-        eventClick={handleEventClick}
-        loading={(isLoading) => setLoading(isLoading)}
-      />
-    ),
-    []
-  );
+	const renderFullCalendar = useMemo(
+		() => (
+			<FullCalendar
+				ref={calendarRef}
+				plugins={[
+					dayGridPlugin,
+					iCalendarPlugin,
+					interactionPlugin,
+					timeGridPlugin,
+					momentTimezonePlugin
+				]}
+				initialView="dayGridMonth"
+				events={{
+					url    : 'basic.ics',
+					format : 'ics'
+				}}
+				headerToolbar={{
+					left   : 'prev,next today',
+					center : 'title',
+					right  : 'dayGridMonth,timeGridWeek,timeGridDay'
+				}}
+				dayMaxEventRows={999}
+				initialDate={new Date().toISOString().slice(0, 10)}
+				navLinks
+				editable
+				dayMaxEvents
+				timeZone="America/New_York"
+				eventClick={handleEventClick}
+				loading={(isLoading) => setLoading(isLoading)}
+			/>
+		),
+		[]
+	);
 
-  return (
-    <div className="App main">
-      <div className="finos-calendar">{renderFullCalendar}</div>
-      {showEventDetails && renderEventDetails()}
-      {loading && <div className="finos-calendar-overlay" />}
-      {loading && <div className="finos-calendar-loading">Loading...</div>}
-    </div>
-  );
+	return (
+		<div className="App main">
+			<div className="finos-calendar">{renderFullCalendar}</div>
+			{showEventDetails && renderEventDetails()}
+			{loading && <div className="finos-calendar-overlay" />}
+			{loading && <div className="finos-calendar-loading">Loading...</div>}
+		</div>
+	);
 }
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import iCalendarPlugin from '@fullcalendar/icalendar';
 import interactionPlugin from '@fullcalendar/interaction';
 import parse from 'html-react-parser';
 import timeGridPlugin from '@fullcalendar/timegrid';
+import momentTimezonePlugin from '@fullcalendar/moment-timezone'
 
 import useEscKey from './hooks/useEscKey';
 
@@ -42,10 +43,10 @@ function App() {
         </button>
         <h2>{eventDetails.title}</h2>
         <div>
-          <strong>Start:</strong> {eventDetails.start.toLocaleString()} EST
+          <strong>Start:</strong> {eventDetails.start.toString()}
         </div>
         <div>
-          <strong>End:</strong> {eventDetails.end.toLocaleString()} EST
+          <strong>End:</strong> {eventDetails.end.toString()}
         </div>
         {parse(description)}
       </div>
@@ -61,6 +62,7 @@ function App() {
           iCalendarPlugin,
           interactionPlugin,
           timeGridPlugin,
+          momentTimezonePlugin,
         ]}
         initialView="dayGridMonth"
         events={{
@@ -77,6 +79,7 @@ function App() {
         navLinks
         editable
         dayMaxEvents
+        timeZone='America/New_York'
         eventClick={handleEventClick}
         loading={(isLoading) => setLoading(isLoading)}
       />


### PR DESCRIPTION
This PR:
- adds @fullcalendar/moment-timezone
- sets the calendars default time zone to 'America/New_York' to match the Google FINOS Community Calendars default time zone
- Displays the time to the user in their local timezone
