### PR TITLE
Link formatting fix (#73)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,7 +103,9 @@ function App() {
 			return outputText;
 		}
 		let formattedDescription = description
-		if(extractUrls(description).length > extractAnchors(description).length) formattedDescription = replaceUrlsWithAnchorTags(description)
+		if(description){
+			if(extractUrls(description).length > extractAnchors(description).length) formattedDescription = replaceUrlsWithAnchorTags(description)
+		}
 
 		return (
 			<div className="finos-calendar-event-details">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,28 @@ function App() {
 			seriesICS = <a href={eventDetails.extendedProps.rootIcsLink}>Series ICS</a>
 		}
 
+		const extractUrls = (text) => {
+			const urlPattern = /(?<!href\s*=\s*["'])\bhttps?:\/\/\S+\b/g;
+			return text.match(urlPattern) || [];
+		};
+
+		const extractAnchors = (text) => {
+			const urlPattern = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"[^>]*>.*?<\/a>/g
+			return text.match(urlPattern) || [];
+		};
+
+		function replaceUrlsWithAnchorTags(inputText) {
+			const urls = extractUrls(inputText)
+			const outputText = urls.reduce((text, url) => {
+				const anchorTag = `<a href="${url}">${url}</a>`;
+				const isAlreadyAnchorTagged = new RegExp(`<a\\s+[^>]*href\\s*=\\s*['"]?${url}['"]?[^>]*>.*?<\\/a>`).test(text);
+				return isAlreadyAnchorTagged ? text : text.replace(url, anchorTag);
+			}, inputText);
+			return outputText;
+		}
+		let formattedDescription = description
+		if(extractUrls(description).length > extractAnchors(description).length) formattedDescription = replaceUrlsWithAnchorTags(description)
+
 		return (
 			<div className="finos-calendar-event-details">
 				<button
@@ -99,7 +121,7 @@ function App() {
 				<h2>{eventDetails.title}</h2>
 				<div>{eventTime}</div>
 				<br />
-				{parse(description)}
+				{parse(formattedDescription)}
 			</div>
 		);
 	};


### PR DESCRIPTION
## Fixes #73 

![Screenshot (332)](https://github.com/finos/calendar/assets/75676784/ededa764-38f8-4a1d-ac2b-72f70b69e749)

## What does this PR do

1- Uses regex to check if the number of URLs in the description is greater than the number of anchor `<a>` tags in the description.
2. If the number of URLs is greater, encloses the URLs in anchor tag that are not already enclosed and replaces it in the description.
3. Does not make any change in description if numberOf(URLs) <= numberOf(Anchors)

## Regex used

1. To identify anchor tags : `/<a\s+(?:[^>]*?\s+)?href="([^"]*)"[^>]*>.*?<\/a>/g`
2. To identify URLs : `/(?<!href\s*=\s*["'])\bhttps?:\/\/\S+\b/g;` (This regex excludes urls directly after `href="`, so that there are no double entries if the href value and the link text have the same string)