### PR TITLE
Fixed epmty description issue (#76)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,8 +65,7 @@ function App() {
 	}
 
 	const renderEventDetails = () => {
-		const description = eventDetails.extendedProps.description.replace(htmlRegex, '');
-
+		let description = eventDetails.extendedProps.description ? eventDetails.extendedProps.description.replace(htmlRegex, '') :  "<i>No description</i>"
 		const fromDate = printDate(eventDetails.start);
 		const toDate = printDate(eventDetails.end);
 		const fromTime = printTime(eventDetails.start);


### PR DESCRIPTION
## Fixes #76

![Screenshot (344)](https://github.com/finos/calendar/assets/75676784/aeac4fe1-a3a7-42c9-b79a-89cedc854b63)


## What does this PR do?

- Prevents app from crashing when an empty event is clicked.
- Displays `No description` for empty description events
