### PR TITLE
Fix : Dark mode styles for fc-popover (#87)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -95,6 +95,10 @@ button.fc-button.finos-calendar-event-details-close {
     background-color: #222;
     color: #eee;
   }
+  .fc-theme-standard .fc-popover{
+    background-color: #222;
+    color: #eee;
+  }
   .finos-calendar-event-details a{
     color: #343;
   }


### PR DESCRIPTION
## Fixes #87 

Applied dark mode styles to fc-popover popup, which were previously left out.

## Screenshot

![Screenshot (370)](https://github.com/finos/calendar/assets/75676784/43f5cf60-2c9a-4b08-a3e3-abc41de87173)
