### PR TITLE
[bug] Event Details popup improvements (#103)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,23 +19,34 @@ body{
   padding: 2rem;
 }
 
+.active-event{
+  background-color: #2c3e5065;
+}
+
 .finos-calendar-event-details {
   position: absolute;
   width: 330px;
-  height: 400px;
+  height: 450px;
   background: #fff;
   border: #333;
   overflow-y: auto;
   z-index: 9999;
-  padding: 2rem;
+  padding: 0 2rem 2rem 2rem;
   box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.75);
   word-break: break-word;
 }
 
+.event-details-buttons{
+  display:flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: 8px 0;
+  position: sticky;
+  background-color: white;
+  top: 0;
+}
+
 button.fc-button.finos-calendar-event-details-close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
@@ -127,9 +138,15 @@ button.fc-button.finos-calendar-event-details-close img{
 }
 
 @media only screen and (prefers-color-scheme : dark){
-  #root, .main, .finos-calendar, .finos-calendar-event-details{
+  #root, .main, .finos-calendar, .finos-calendar-event-details, .event-details-buttons{
     background-color: #222;
     color: #eee;
+  }
+  .fc-event:hover{
+    background-color: #3c3c3c;
+  }
+  .active-event{
+    background-color: #eeeeee20;
   }
   .fc-theme-standard .fc-popover{
     background-color: #222;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ function App() {
   const eventDetailRef = createRef();
 
   const [loading, setLoading] = useState(true);
+  const [clickedEvent, setClickedEvent] = useState([]);
   const [showEventDetails, setShowEventDetails] = useState(false);
   const [eventDetails, setEventDetails] = useState(false);
   const [aspectRatio, setAspectRatio] = useState(
@@ -64,19 +65,18 @@ function App() {
     setPopupPosition({ left: position.left + 'px', top: position.top + 'px' });
   };
 
-  const clickedEvent = [];
-
   const handleEventClick = useCallback((clickInfo) => {
     window.outerWidth > 600 && createPopupPosition(clickInfo.jsEvent);
     setEventDetails(clickInfo.event);
     setShowEventDetails(true);
     if(clickedEvent.length){
       clickedEvent[0].classList.remove('active-event');
-      clickedEvent.pop();
+      setClickedEvent([]);
     }
-    clickedEvent.push(clickInfo.jsEvent.target.closest('a.fc-event'));
-    clickedEvent[0].classList.add('active-event');
-  }, []);
+    const event = clickInfo.jsEvent.target.closest('a.fc-event');
+    event.classList.add('active-event');
+    setClickedEvent([event]);
+  }, [clickedEvent]);
 
   useEffect(()=>{
     const closeOnOutsideClick = (e)=>{

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,7 +86,7 @@ function App() {
 
     document.body.addEventListener('click', closeOnOutsideClick);
     return ()=> document.removeEventListener('click', closeOnOutsideClick);
-  }, [ eventDetailRef ]);
+  }, [ eventDetailRef, showEventDetails ]);
 
   function downloadICSFile() {
     // console.log("print ics");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import { mdiCalendarRange, mdiClose, mdiMapMarkerOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import parse from 'html-react-parser';
-import { createRef, useCallback, useMemo, useState } from 'react';
+import { createRef, useCallback, useEffect, useMemo, useState } from 'react';
 import useEscKey from './hooks/useEscKey';
 import './App.css';
 
@@ -16,6 +16,7 @@ const htmlRegex = /<\/*html-blob>/;
 
 function App() {
   const calendarRef = createRef();
+  const eventDetailRef = createRef();
 
   const [loading, setLoading] = useState(true);
   const [showEventDetails, setShowEventDetails] = useState(false);
@@ -45,7 +46,7 @@ function App() {
   };
 
   const createPopupPosition = (event) => {
-    const popup = { width: 330, height: 400 };
+    const popup = { width: 330, height: 450 };
     let position = { top: event.pageY + 20, left: event.pageX + 50 };
     if (
       event.pageX + popup.width + 140 > window.outerWidth ||
@@ -63,11 +64,29 @@ function App() {
     setPopupPosition({ left: position.left + 'px', top: position.top + 'px' });
   };
 
+  const clickedEvent = [];
+
   const handleEventClick = useCallback((clickInfo) => {
     window.outerWidth > 600 && createPopupPosition(clickInfo.jsEvent);
     setEventDetails(clickInfo.event);
     setShowEventDetails(true);
+    if(clickedEvent.length){
+      clickedEvent[0].classList.remove('active-event');
+      clickedEvent.pop();
+    }
+    clickedEvent.push(clickInfo.jsEvent.target.closest('a.fc-event'));
+    clickedEvent[0].classList.add('active-event');
   }, []);
+
+  useEffect(()=>{
+    const closeOnOutsideClick = (e)=>{
+      if(e.target.closest('.fc-event') || eventDetailRef.current == null) return;
+      if(showEventDetails && !eventDetailRef.current.contains(e.target)) setShowEventDetails(false);
+    };
+
+    document.body.addEventListener('click', closeOnOutsideClick);
+    return ()=> document.removeEventListener('click', closeOnOutsideClick);
+  }, [ eventDetailRef ]);
 
   function downloadICSFile() {
     // console.log("print ics");
@@ -165,16 +184,19 @@ function App() {
     }
 
     return (
-      <div className="finos-calendar-event-details" style={popupPosition}>
-        <button
-          onClick={() => setShowEventDetails(false)}
-          className="fc-button finos-calendar-event-details-close"
-        >
-          <Icon path={mdiClose} size={1} />
-        </button>
-        <button onClick={() => downloadICSFile()} className="fc-button">
-          Event ICS
-        </button>
+      <div ref={eventDetailRef} key={description} className="finos-calendar-event-details" style={popupPosition}>
+
+        <div className="event-details-buttons">
+          <button onClick={() => downloadICSFile()} className="fc-button">
+            Event ICS
+          </button>
+          <button
+            onClick={() => setShowEventDetails(false)}
+            className="fc-button finos-calendar-event-details-close">
+            <Icon path={mdiClose} size={1} />
+          </button>
+        </div>
+
         {/* <div>{seriesICS}</div> */}
         <h2 className="event-title">{eventDetails.title}</h2>
         <div className="event-time">


### PR DESCRIPTION
## Fixes #103 

This PR improves upon the existing Event Details popup component.

## Changes/Updates

1. Popup header is now sticks to the top on scroll.
2. Event Details popup closes if a click event happens outside the popup.
3. The last opened event is now highlighted.
4. Event popup is re-rendered for every event click resulting the scroll state to not persist between popups.
5. Adds hover state for events in dark mode

## Screenshots

1. Highlighted last clicked event
![Screenshot (398)](https://github.com/finos/calendar/assets/75676784/f75c99b6-a5fa-4b15-8921-6c7a4ce498f0)

2. Sticky popup header
![Screenshot (399)](https://github.com/finos/calendar/assets/75676784/a667b138-2875-444d-9c2f-b65419494f00)

3. Event hover state in dark mode
![Screenshot (400)](https://github.com/finos/calendar/assets/75676784/4bfb5878-928d-455a-8b9a-b3deb94ef57e)
