### PR TITLE
Add time zone field to event details popup 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,6 +70,13 @@ button.fc-button.finos-calendar-event-details-close img{
   gap: 5px;
 }
 
+.event-timeZone{
+  font-size: 14px;
+  margin-bottom: 6px;
+  display: flex;
+  gap: 5px;
+}
+
 .event-location{
   display:flex;
   gap: 5px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import FullCalendar from '@fullcalendar/react';
 import rrulePlugin from '@fullcalendar/rrule';
 import timeGridPlugin from '@fullcalendar/timegrid';
 
-import { mdiCalendarRange, mdiClose, mdiMapMarkerOutline } from '@mdi/js';
+import { mdiCalendarRange, mdiClose, mdiMapMarkerOutline, mdiClock } from '@mdi/js';
 import Icon from '@mdi/react';
 import parse from 'html-react-parser';
 import { createRef, useCallback, useEffect, useMemo, useState } from 'react';
@@ -136,6 +136,7 @@ function App() {
     const toDate = printDate(eventDetails.end);
     const fromTime = printTime(eventDetails.start);
     const toTime = printTime(eventDetails.end);
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     let eventTime = '';
     if (fromDate == toDate) {
       eventTime = fromDate + ' ' + fromTime + ' - ' + toTime;
@@ -212,6 +213,12 @@ function App() {
             <Icon path={mdiCalendarRange} size={0.75} />
           </div>
           <div>{eventTime}</div>
+        </div>
+        <div className="event-timeZone">
+          <div className="icon">
+            <Icon path={mdiClock} size={0.75} />
+          </div>
+          <div>Time Zone: {timeZone}</div>
         </div>
         {eventLocation && (
           <div className="event-location">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import FullCalendar from '@fullcalendar/react';
 import rrulePlugin from '@fullcalendar/rrule';
 import timeGridPlugin from '@fullcalendar/timegrid';
 
-import { mdiCalendarRange, mdiClose, mdiMapMarkerOutline, mdiClock } from '@mdi/js';
+import { mdiCalendarRange, mdiClock, mdiClose, mdiMapMarkerOutline } from '@mdi/js';
 import Icon from '@mdi/react';
 import parse from 'html-react-parser';
 import { createRef, useCallback, useEffect, useMemo, useState } from 'react';


### PR DESCRIPTION
Adds Time Zone field to events detail pop up. To help users know that the time is displayed in their local time zone.


![Screenshot 2024-04-09 103300](https://github.com/finos/calendar/assets/36825759/7f5cf22c-0bb1-42d1-8a5f-905a9e87951a)
