### PR TITLE
Google api pagination

### DIFF
--- a/scripts/googleapi2events.js
+++ b/scripts/googleapi2events.js
@@ -143,7 +143,9 @@ async function getGoogleEvents(queryName, dynamicOptions) {
 	let allItems = [];
 	let nextPageToken = null;
 
+  // Loop to fetch events until there are no more pages
 	do {
+    // If nextPageToken is not null, set it in dynamicOptions to fetch the next page
 		if (nextPageToken) {
 			dynamicOptions.set('pageToken', nextPageToken);
 		}
@@ -151,6 +153,7 @@ async function getGoogleEvents(queryName, dynamicOptions) {
 		const itemsAsync = await calendar.events.list(getApiOptions(dynamicOptions));
 		const items = itemsAsync.data.items;
 		allItems = allItems.concat(items);
+    // set page token for the next iteration
 		nextPageToken = itemsAsync.data.nextPageToken;
 	} while (nextPageToken);
 

--- a/scripts/googleapi2events.js
+++ b/scripts/googleapi2events.js
@@ -140,20 +140,26 @@ function getApiOptions(options) {
 // If results hit the limit of 2500 entries, an error is thrown
 // Accepts additional options to pass to the API
 async function getGoogleEvents(queryName, dynamicOptions) {
-  const itemsAsync = await calendar.events.list(getApiOptions(dynamicOptions));
-  const items = itemsAsync.data.items;
+	let allItems = [];
+	let nextPageToken = null;
 
-  if (items.length == 0) {
-    throw new Error(queryName + 'No events returned!');
-  } else if (items.length == 2500) {
-    throw new Error(
-      queryName + ' Events retrieved reached API limit!',
-      items.length
-    );
-  } else {
-    console.log(queryName + ' Events retrieved:', items.length);
-  }
-  return items;
+	do {
+		if (nextPageToken) {
+			dynamicOptions.set('pageToken', nextPageToken);
+		}
+
+		const itemsAsync = await calendar.events.list(getApiOptions(dynamicOptions));
+		const items = itemsAsync.data.items;
+		allItems = allItems.concat(items);
+		nextPageToken = itemsAsync.data.nextPageToken;
+	} while (nextPageToken);
+
+	if (allItems.length == 0) {
+		throw new Error(queryName + ' No events returned!');
+	} else {
+		console.log(queryName + ' Events retrieved:', allItems.length);
+	}
+	return allItems;
 }
 
 // Fetches events from Google API and transforms them


### PR DESCRIPTION
I Modify the getGoogleEvents function to handle pagination as we were hitting an API limit.

It now repeatedly fetches events until no more pages are left and concatenate the events from each page until all events are retrieved.