### PR TITLE
add headers file

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  Content-Security-Policy: frame-ancestors 'self' https://finos.org


### PR DESCRIPTION
Updated the X-Frame-Options and Content-Security-Policy headers for calendar.finos.org to permit embedding in the finos.org/calendar page.